### PR TITLE
Change cucumber locale to 'de' and fix cucumber tests #112

### DIFF
--- a/features/step_definitions/_general.rb
+++ b/features/step_definitions/_general.rb
@@ -1,6 +1,4 @@
 Before do
   init_data_helper
   OmniAuth.config.test_mode = true
-  # Set locale to English since cucumber tests are written in English
-  I18n.default_locale = :en
 end

--- a/features/step_definitions/interaction.rb
+++ b/features/step_definitions/interaction.rb
@@ -1,3 +1,9 @@
 When (/^he clicks '(.*)'$/) do |text|
-  click_on text
+  translations = {
+    'Connect with OpenID' => ['devise.registrations.link_provider', provider: 'OpenID'],
+    'Disconnect from OpenID' => ['devise.registrations.unlink_provider', provider: 'OpenID']
+  }
+  translations.default = 'No translation found'
+
+  click_on I18n.t(*translations[text])
 end


### PR DESCRIPTION
Closes #112.

In #111 the main language for the application had been set to German but the language for the Cucumber feature tests remained English. When somebody added only the German translation (which should be legal) for an i18ned string, the Cucumber tests failed at times. This PR changes the test locale to 'de' and fixes Cucumber tests which rely on English translations in the UI (but not in the prettiest way).