### PR TITLE
Enable responsiveness of sport portal #115

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
     <title><%= t('appname') %></title>
     <%= csrf_meta_tags %>
 


### PR DESCRIPTION
Closes #115.

Some elements were already responsive before but the page didn't "switch" into mobile mode when displayed on a smartphone. This should now be resolved.