### PR TITLE
Hotfix/#163/correct user authorization

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,17 +27,13 @@ Rails.application.routes.draw do
   # Sets the devise scope to be used in the controller.
   # http://www.rubydoc.info/github/plataformatec/devise/ActionDispatch%2FRouting%2FMapper%3Adevise_scope
   devise_scope :user do
-    resources :users, only: [:index, :show]
-    get '/users/:id/dashboard', to: 'users#dashboard'
-    get '/users/:id/link', to: 'users#link'
-    get '/users/:id/unlink', to: 'users#unlink'
-  end
-
-  #Define route for user dashboard
-  resources :users do
-    get 'dashboard', on: :member
-    get 'link', on: :member
-    get 'unlink', on: :member
+    resources :users, only: [:index, :show, :edit, :update] do
+      member do
+        get 'dashboard'
+        get 'link'
+        get 'unlink'
+      end
+    end
   end
 
   #Define route for Create Event Button

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -68,6 +68,24 @@ RSpec.describe UsersController, type: :controller do
     end
   end
 
+  describe 'GET #edit' do
+    before :each do
+      @request.env['devise.mapping'] = Devise.mappings[:user]
+      @user = User.create! valid_attributes
+    end
+
+    it 'should show the edit page when the user is logged in' do
+      sign_in @user
+      get :edit, params: { id: @user.to_param }
+      expect(response).to be_success
+    end
+
+    it 'should redirect to the sign in page when no user is logged in' do
+      get :edit, params: { id: @user.to_param }
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+
   describe 'POST #create' do
     it 'creates a new user with valid params' do
       @request.env['devise.mapping'] = Devise.mappings[:user]


### PR DESCRIPTION
This will fix #163.

The issue was caused by a duplicate declaration of routes in the `routes.rb`. Because the user routes were not in a devise scope, a before action of the devise registration controller raised an error.

The issue was resolved by removing the duplicate root and a test was put in place covering the erroneous case.