### PR TITLE
Hotfix: Update schema.rb to match latest migration #29

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171212150919) do
+ActiveRecord::Schema.define(version: 20180102181138) do
 
   create_table "events", force: :cascade do |t|
     t.string "name"
@@ -88,6 +88,7 @@ ActiveRecord::Schema.define(version: 20171212150919) do
     t.text "description"
     t.string "kind_of_sport"
     t.boolean "private"
+    t.boolean "single", default: false
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
In PR https://github.com/hpi-swt2/sport-portal/pull/283 (work of team issuenumber5 on issue #29) it seems the `schema.rb` wasn't updated together with the new migration introduced in the PR. This leads to a failing dev deployment on Heroku so that the deployment is currently still at 8eaf4063.