### PR TITLE
#252/kickerz/team logo bug fixed

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,7 +1,7 @@
 class TeamsController < ApplicationController
   before_action :set_team, only: [:show, :edit, :update, :destroy, :assign_ownership, :delete_membership, :delete_ownership, :perform_action_on_multiple_members, :assign_membership_by_email]
   before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
-  load_and_authorize_resource :team, only: [:index, :show, :new, :edit, :create, :update, :destroy]
+  authorize_resource :team, only: [:index, :show, :new, :edit, :create, :update, :destroy]
 
   # GET /teams
   def index


### PR DESCRIPTION
There was a bug when creating a team with a logo (IOError stream closed). This did not occur when you updated a team with a logo.

https://github.com/janko-m/shrine/issues/107
The last post in this thread says that there is a problem with uploading while using load_and_authorize_resource.

I changed load_and_authorize_resource to authorize_resource and everything works fine now.