### PR TITLE
Make asterisk in team creation page indication required field reappear.

### DIFF
--- a/app/views/teams/_form.html.erb
+++ b/app/views/teams/_form.html.erb
@@ -5,7 +5,7 @@
   <%= render partial: "application/validation_errors", locals: {model: @team} %>
 
   <div class="form-group">
-    <%= f.label :name, :class => 'control-label col-lg-2' %>
+    <%= f.label :name, :class => 'control-label col-lg-2 required', :required => true %>
     <div class="col-lg-10">
       <%= f.text_field :name, :class => 'form-control' %>
       <%= f.error_span(:name) %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -83,13 +83,6 @@ ActiveRecord::Schema.define(version: 20180107175546) do
     t.index ["user_id"], name: "index_organizers_on_user_id"
   end
 
-  create_table "participants", force: :cascade do |t|
-    t.integer "attendee_id"
-    t.string "attendee_type"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "team_users", force: :cascade do |t|
     t.integer "team_id", null: false
     t.integer "user_id", null: false
@@ -105,8 +98,8 @@ ActiveRecord::Schema.define(version: 20180107175546) do
     t.text "description"
     t.string "kind_of_sport"
     t.boolean "private"
-    t.boolean "single", default: false
     t.text "avatar_data"
+    t.boolean "single", default: false
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
For some reason the asterisk for required fields in team creation disappeared, this PR fixes this. 