### PR TITLE
Flexibus/#500/edit profile ui changes

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -70,7 +70,7 @@ body {
     padding-bottom: 120px;
   }
 
-  * {
+  *, .form-horizontal .form-group input.form-control {
     font-size: 1.2rem;
   }
 
@@ -92,7 +92,7 @@ body {
     padding-bottom: 50px;
   }
 
-  * {
+  *, .form-horizontal .form-group input.form-control {
     font-size: 1.2rem;
   }
 
@@ -109,6 +109,12 @@ body {
 
   h3 {
     font-size: 2.2rem;
+  }
+}
+
+@media screen and (min-width: 1200px) {
+  .form-horizontal .form-group input.form-control {
+    margin-top: -10px;
   }
 }
 

--- a/app/assets/stylesheets/teams.css
+++ b/app/assets/stylesheets/teams.css
@@ -9,6 +9,11 @@ label.required:after {
   font-size: 0.75em;
   font-weight: normal;
 }
+
+label.required {
+  margin-top: -0.5px;
+}
+
 select.filterSelect{
   display: block;
 }

--- a/app/assets/stylesheets/users.css
+++ b/app/assets/stylesheets/users.css
@@ -1,0 +1,37 @@
+.btn-save-edit-user, .btn-cancel-edit-user {
+    border-radius: 100px;
+    padding: 10px 60px;
+    font-size: 1.2rem;
+    letter-spacing: 0;
+    height: auto;
+}
+
+.btn-save-edit-user {
+    color: #FFFFFF;
+    background: #1CA9E5;
+    margin-right: 25px;
+}
+
+.btn-save-edit-user:hover {
+    color: #FFFFFF;
+    background: #1CC3FF;
+}
+
+.btn-cancel-edit-user {
+    color: #737373;
+    background: #FFFFFF;
+    border: 1px solid #9E9E9E;
+}
+
+.btn-cancel-edit-user:hover {
+    color: #FFFFFF;
+    background: #9E9E9E;
+}
+
+#save-cancel-section > div > * {
+    margin-top: 30px;
+}
+
+#delete-account-section {
+    margin-top: 50px;
+}

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -52,12 +52,7 @@
   <div class="form-group row">
     <%= f.label :telegram_username, class: 'control-label col-lg-2' %>
     <div class="col-lg-10">
-      <div class="input-group">
-        <div class="input-group-addon">
-          <i class="fa fa-telegram fa-lg"></i>
-        </div>
-        <%= f.text_field :telegram_username, class: 'form-control' %>
-      </div>
+      <%= f.text_field :telegram_username, class: 'form-control' %>
     </div>
   </div>
   <div class="form-group row">

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,25 +1,26 @@
 <%= render partial: "application/validation_errors", locals: {model: @user} %>
 
+<%= stylesheet_link_tag 'users' %>
 <div class="page-header">
   <h1><%= t 'view.user.edit_profile' %></h1>
 </div>
 
 <%= form_for(@user, url: user_path(@user), html: { class: 'form-horizontal user', method: :put }) do |f| %>
-  <div class="form-group">
+  <div class="form-group row">
     <%= f.label :first_name, class: 'control-label col-lg-2' %>
     <div class="col-lg-10">
       <%= f.text_field :first_name, autofocus: true, class: 'form-control' %>
       <%= f.error_span(:first_name) %>
     </div>
   </div>
-  <div class="form-group">
+  <div class="form-group row">
     <%= f.label :last_name, class: 'control-label col-lg-2' %>
     <div class="col-lg-10">
       <%= f.text_field :last_name, class: 'form-control' %>
       <%= f.error_span(:last_name) %>
     </div>
   </div>
-  <div class="form-group">
+  <div class="form-group row">
     <%= f.label :email, class: 'control-label col-lg-2' %>
     <div class="col-lg-10">
       <%= f.email_field :email, class: 'form-control' %>
@@ -62,7 +63,7 @@
     </div>
   </div>
   <% unless @user.has_omniauth? %>
-    <div class="form-group">
+    <div class="form-group row">
       <%= f.label :password, class: 'control-label col-lg-2' %>
       <div class="col-lg-10">
         <%= f.password_field :password, autocomplete: "off", class: 'form-control' %>
@@ -70,7 +71,7 @@
         <p class="help-block"><i><%= t('.leave_blank_if_you_don_t_want_to_change_it') %></i></p>
       </div>
     </div>
-    <div class="form-group">
+    <div class="form-group row">
       <%= f.label :password_confirmation, class: 'control-label col-lg-2' %>
       <div class="col-lg-10">
         <%= f.password_field :password_confirmation, class: 'form-control'  %>
@@ -78,7 +79,7 @@
       </div>
     </div>
 
-    <div class="form-group">
+    <div class="form-group row">
       <%= f.label :current_password, class: 'control-label col-lg-2' %>
       <div class="col-lg-10">
         <% if @user.errors.include? :current_password %>
@@ -91,7 +92,7 @@
       </div>
     </div>
   <% end %>
-  <div class="form-group">
+  <div class="form-group row">
     <label class="control-label col-lg-2">OpenID</label>
     <div class="col-lg-10">
       <% if @user.has_omniauth? %>
@@ -109,11 +110,15 @@
       <% end %>
     </div>
   </div>
-  <div class="form-group">
+  <div class="form-group row" id="save-cancel-section">
     <div class="col-lg-offset-2 col-lg-10">
-      <%= f.submit nil, class: 'btn btn-primary' %>
+      <%= f.submit nil, class: 'btn btn-save-edit-user' %>
       <%= link_to t('.cancel', default: t('helpers.links.cancel')),
-                user_path(@user), class: 'btn btn-default' %>
+                user_path(@user), class: 'btn btn-cancel-edit-user' %>
+    </div>
+  </div>
+  <div class="form-group row" id="delete-account-section">
+    <div class="col-lg-offset-2 col-lg-10">
       <%= t('.unhappy') %>? <%= link_to t('.cancel_this_account'), user_path(@user), method: :delete %>.
     </div>
   </div>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -2,9 +2,8 @@
 
 # Version of your assets, change this if you want to expire all your assets.
 Rails.application.config.assets.version = '1.0'
-Rails.application.config.assets.precompile += %w( sign_in.css navbar.css welcome.css footer.css  teams.css tile.css event_cards.css errors.css)
+Rails.application.config.assets.precompile += %w( sign_in.css navbar.css welcome.css footer.css  teams.css tile.css event_cards.css errors.css users.css)
 Rails.application.config.assets.precompile << /\.(?:svg|eot|woff|ttf|otf)$/
-Rails.application.config.assets.precompile += %w( event_cards.css )
 
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path

--- a/config/locales/de.helpers.yml
+++ b/config/locales/de.helpers.yml
@@ -40,7 +40,7 @@ de:
     submit:
       create: "Erstelle %{model}"
       submit: "Speichere %{model}"
-      update: "Aktualisiere %{model}"
+      update: "Speichern"
       delete: "Lösche %{model}"
     select:
       prompt: "Bitte wähle"

--- a/config/locales/en.helpers.yml
+++ b/config/locales/en.helpers.yml
@@ -34,7 +34,7 @@ en:
       delete: "Delete %{model}"
       create: "Create %{model}"
       submit: "Save %{model}"
-      update: "Update %{model}"
+      update: "Save"
     select:
       prompt: "Please select"
       option_operator: "or"

--- a/spec/features/event/rankinglist_spec.rb
+++ b/spec/features/event/rankinglist_spec.rb
@@ -41,7 +41,7 @@ describe 'Rankinglists', type: :feature do
     visit edit_results_match_path(@match)
     expect(current_path).to match(/\/matches\/\d+\/edit_results/)
     expect(@match).not_to equal(nil)
-    click_link_or_button(I18n.t("helpers.submit.update", model: Match.model_name.human))
+    click_link_or_button(I18n.t("helpers.submit.update"))
   end
 
   context 'elo ranking lists' do
@@ -73,7 +73,7 @@ describe 'Rankinglists', type: :feature do
           end
         end
       end
-      click_link_or_button(I18n.t("helpers.submit.update", model: Match.model_name.human))
+      click_link_or_button(I18n.t("helpers.submit.update"))
       participant = @elo_event.participants.where("team_id = ?", @elo_event.team_of(@user)).first
       participant2 = @elo_event.participants.where("team_id = ?", @elo_event.team_of(@user2)).first
       expect(participant.rating).to eq(1016)
@@ -91,7 +91,7 @@ describe 'Rankinglists', type: :feature do
           end
         end
       end
-      click_link_or_button(I18n.t("helpers.submit.update", model: Match.model_name.human))
+      click_link_or_button(I18n.t("helpers.submit.update"))
       participant = @elo_event.participants.where("team_id = ?", @elo_event.team_of(@user)).first
       participant2 = @elo_event.participants.where("team_id = ?", @elo_event.team_of(@user2)).first
       expect(participant.rating).to eq(984)
@@ -109,7 +109,7 @@ describe 'Rankinglists', type: :feature do
           end
         end
       end
-      click_link_or_button(I18n.t("helpers.submit.update", model: Match.model_name.human))
+      click_link_or_button(I18n.t("helpers.submit.update"))
       participant = @elo_event.participants.where("team_id = ?", @elo_event.team_of(@user)).first
       participant2 = @elo_event.participants.where("team_id = ?", @elo_event.team_of(@user2)).first
       expect(participant.rating).to eq(1000)


### PR DESCRIPTION
Closes #500.
- buttons to save changes on edit pages now show "Speichern" instead of "Aktualisiere \<model\>" everywhere
- label and text-input sizes and alignment should be fixed for all forms, not just the one on the edit user page