### PR TITLE
Remove unnecessary buttons from schedule page

### DIFF
--- a/app/views/events/_schedule_league.html.erb
+++ b/app/views/events/_schedule_league.html.erb
@@ -65,15 +65,8 @@
         <% end %>
       </td>
       <td>
-        <%= link_to t('.show', default: t('helpers.links.show')),
+        <%= link_to t('events.schedule.insert_results'),
                     match_path(match), :class => 'btn btn-default btn-xs' %>
-        <%= link_to t('.edit', default: t('helpers.links.edit')),
-                    edit_match_path(match), :class => 'btn btn-default btn-xs' %>
-        <%= link_to t('.destroy', default: t('helpers.links.destroy')),
-                    match_path(match),
-                    :method => :delete,
-                    :data => { :confirm => t('.confirm', default: t('helpers.links.confirm')) },
-                    :class => 'btn btn-xs btn-danger' %>
       </td>
     </tr>
   <% end %>

--- a/app/views/events/_schedule_tournament.html.erb
+++ b/app/views/events/_schedule_tournament.html.erb
@@ -57,10 +57,8 @@
         <% end %>
       </td>
       <td>
-        <%= link_to t('.show', default: t('helpers.links.show')),
+        <%= link_to t('events.schedule.insert_results'),
                     match_path(match), :class => 'btn btn-default btn-xs' %>
-        <%= link_to t('.edit', default: t('helpers.links.edit')),
-                    edit_match_path(match), :class => 'btn btn-default btn-xs' %>
       </td>
     </tr>
   <% end %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -344,6 +344,7 @@ de:
       preliminaries: "Vorrunde %{round}"
       to: "bis"
       appointment: "Termin"
+      insert_results: "Ergebnisse eintragen"
     gamemode:
       round_robin: "Jeder gegen Jeden"
       two_halfs: "Hin- und Rückrunde"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -131,6 +131,8 @@ en:
       infinite: "unlimited"
     overview:
       not_available_for_leagues: 'No overview available for leagues.'
+    schedule:
+      insert_results: "Insert result"
 
   teams:
       show:

--- a/spec/views/events/schedule.html.erb_spec.rb
+++ b/spec/views/events/schedule.html.erb_spec.rb
@@ -29,6 +29,11 @@ RSpec.describe 'events/schedule', type: :view do
       render
       expect(rendered).to have_selector(:link_or_button, t('events.schedule.edit_date'))
     end
+
+    it 'has insert results button for matches' do
+      render
+      expect(rendered).to have_selector(:link_or_button, t('events.schedule.insert_results'))
+    end
   end
 
   describe 'linktext for single player league' do


### PR DESCRIPTION
Task was to delete two buttons (for tournament only one) and rename the remaining one, see #524.