### PR TITLE
Kickerz/refresh text in invite modal

### DIFF
--- a/app/assets/javascripts/teamscripts/teams.js
+++ b/app/assets/javascripts/teamscripts/teams.js
@@ -1,22 +1,29 @@
 $(document).ready(function(){
-// Place all the behaviors and hooks related to the matching controller here.
-// All this logic will automatically be available in application.js.
-var getUrlParameter = function getUrlParameter(sParam) {
-    var sPageURL = decodeURIComponent(window.location.search.substring(1)),
-        sURLVariables = sPageURL.split('&'),
-        sParameterName,
-        i;
-        
-    for (i = 0; i < sURLVariables.length; i++) {
-        sParameterName = sURLVariables[i].split('=');
+    // Place all the behaviors and hooks related to the matching controller here.
+    // All this logic will automatically be available in application.js.
 
-        if (sParameterName[0] === sParam) {
-            return sParameterName[1] === undefined ? true : sParameterName[1];
+    var getUrlParameter = function getUrlParameter(sParam) {
+        var sPageURL = decodeURIComponent(window.location.search.substring(1)),
+            sURLVariables = sPageURL.split('&'),
+            sParameterName,
+            i;
+            
+        for (i = 0; i < sURLVariables.length; i++) {
+            sParameterName = sURLVariables[i].split('=');
+
+            if (sParameterName[0] === sParam) {
+                return sParameterName[1] === undefined ? true : sParameterName[1];
+            }
         }
-    }
-};
+    };
 
-if(getUrlParameter('filter') == "true"){
-    $('.filterSelect').val($(".filterSelect option:eq(1)").val())
-}
+    if(getUrlParameter('filter') == "true"){
+        $('.filterSelect').val($(".filterSelect option:eq(1)").val())
+    }
+
+    // clear modal used for inviting new members to a team after closing it
+    $(".modal").on("hidden.bs.modal", function(){
+        $(".modal-body #email").val("");
+    });
 });
+

--- a/app/assets/stylesheets/teams.css
+++ b/app/assets/stylesheets/teams.css
@@ -3,6 +3,10 @@
   They will automatically be included in application.css.
 */
 
+.modal-backdrop.fade.in {
+  opacity: 0;
+}
+
 label.required:after {
   content: "*";
   vertical-align: 0.5em;


### PR DESCRIPTION
Adds the necassary script to clear the modal when it is closed. Also removes the black backdrop of the modal as specified in the issues's 'note'. ;)

 
After some trying, I omitted testing, since,

in short: JS testing in Capybara is a bitch and we never really test view side js anyways.

in full: in order to test JS in our tests we'd need to switch the `Capybara driver` to `webkit` for the test only, which would require installing the necessary gem, which is, it seems, [not so easy](https://github.com/thoughtbot/capybara-webkit/wiki/Installing-Qt-and-compiling-capybara-webkit).
If someone still insists on testing the script, I'd be glad to receive some input on how go about it either using the problematic approach I mentioned above or another one.

Make sure to use the whitespace insensitive GitHub view. :)